### PR TITLE
Allow relative path in _parse_include

### DIFF
--- a/redis_lua/regions.py
+++ b/redis_lua/regions.py
@@ -402,16 +402,18 @@ class ScriptParser(object):
         get_script_by_name,
     ):
         match = re.match(
-            r'^\s*%include\s+"(?P<name>[\w\d_\-/\\]+)"\s*$',
+            r'^\s*%include\s+"(?P<name>[\w\d_\-/\\.]+)"\s*$',
             statement,
         )
 
         if match:
             # We don't want backslashes in script names. Life is already
             # complex enough.
-            name = os.path.join(
-                current_path,
-                match.group('name'),
+            name = os.path.relpath(
+                os.path.join(
+                    current_path,
+                    match.group('name'),
+                )
             ).replace(os.path.sep, '/')
             script = get_script_by_name(name=name)
 

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -746,6 +746,8 @@ class ScriptParserTests(TestCase):
             '%include "foo"',
             '%include "foo"',
             'local e = 4;',
+            '%include "../foo"',
+            '%include "./bar/../foo"',
         ]
         content = '\n'.join(contents)
         script = Script(
@@ -779,14 +781,24 @@ class ScriptParserTests(TestCase):
                     content='%include "foo"',
                 ),
                 TextRegion(content=contents[5]),
+                ScriptRegion(
+                    script=script,
+                    content='%include "../foo"',
+                ),
+                ScriptRegion(
+                    script=script,
+                    content='%include "./bar/../foo"',
+                ),
             ],
             regions,
         )
         self.assertEqual(
             [
-                call(name="./%s" % script.name),
-                call(name="./%s" % script.name),
-                call(name="./%s" % script.name),
+                call(name="%s" % script.name),
+                call(name="%s" % script.name),
+                call(name="%s" % script.name),
+                call(name="../%s" % script.name),
+                call(name="%s" % script.name),
             ],
             get_script_by_name.mock_calls[:],
         )


### PR DESCRIPTION
Found a bug with relative path include. "." are not accepted in include path regex.